### PR TITLE
[bugfix] use a default factor for mutable values

### DIFF
--- a/grip/environments/domain_randomiser.py
+++ b/grip/environments/domain_randomiser.py
@@ -2,7 +2,7 @@ from ..io import get_data_path, log
 from ..robot import BulletRobot, BulletObject, BulletWorld
 import pybullet as p
 import numpy as np
-from typing import Union, Tuple, List, Callable
+from typing import Union, Tuple, List
 from dataclasses import dataclass, field
 
 base_dir = get_data_path()

--- a/grip/environments/domain_randomiser.py
+++ b/grip/environments/domain_randomiser.py
@@ -2,8 +2,8 @@ from ..io import get_data_path, log
 from ..robot import BulletRobot, BulletObject, BulletWorld
 import pybullet as p
 import numpy as np
-from typing import Union, Tuple, List
-from dataclasses import dataclass
+from typing import Union, Tuple, List, Callable
+from dataclasses import dataclass, field
 
 base_dir = get_data_path()
 
@@ -72,8 +72,8 @@ class TextureRandomiser:
 class LightingParameters:
     """This class represents the basic phong illumination model parameters"""
 
-    light_direction: np.ndarray = np.ones(3)
-    light_colour: np.ndarray = np.ones(3)
+    light_direction: np.ndarray = field(default_factory=lambda: np.ones(3))
+    light_colour: np.ndarray = field(default_factory=lambda: np.ones(3))
     specular_coef: int = 1
     diffuse_coef: int = 1
     ambient_coef: int = 1


### PR DESCRIPTION
This fixes the setup of the dataclass.  These appear as errors in python 3.12, so this fix is part of the upgrade for supporting python 3.12