### PR TITLE
[bugfix] Remove unused version import

### DIFF
--- a/grip/__init__.py
+++ b/grip/__init__.py
@@ -1,5 +1,3 @@
-from .version import __version__
-
 # from gym.envs.registration import register
 
 # register(


### PR DESCRIPTION
Removing lingering import from when version was determined dynamically using a .py file. This fixes all tests.